### PR TITLE
testing: e2e ci workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,6 @@ name: Docker Build & Push Nilliond (main)
 # and pushes the image to https://ghcr.io/cosmos/ibc-go-simd
 on:
   workflow_dispatch:
-  push:
 
 env:
   REGISTRY: ghcr.io
@@ -20,7 +19,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
       with:
-        images: ${{ env.REGISTRY }}/01builders/${{ env.IMAGE_NAME }}
+        images: ${{ env.REGISTRY }}/NillionNetwork/${{ env.IMAGE_NAME }}
 
     - name: Build Docker image
       uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0

--- a/.github/workflows/ibc-e2e.yml
+++ b/.github/workflows/ibc-e2e.yml
@@ -1,0 +1,57 @@
+---
+    name: Run ibc E2E Tests
+    on:
+      workflow_dispatch:
+    jobs:
+      e2e:
+        runs-on: ubuntu-latest
+        strategy:
+          fail-fast: false # ensure that a single test failure doesn't cause all tests to fail
+          matrix:
+            # entrypoint corresponds to the test function in the test files which fall under the e2e directory.
+            # test is the name of the test function to be run.
+            # see the e2e docs https://github.com/cosmos/ibc-go/tree/main/e2e for more details.
+            include:
+              # e2e ibc transfer
+              - test: TestMsgTransfer_Succeeds_Nonincentivized
+                entrypoint: TestTransferTestSuite
+              # Uses governance to change params
+              - test: TestSendEnabledParam
+                entrypoint: TestTransferTestSuite
+        steps:
+          - name: Checkout the ibc-go repo.
+            uses: actions/checkout@v3
+            with:
+              repository: cosmos/ibc-go
+              ref: support-arbitrary-binaries-in-e2es
+              path: ibc-go
+
+          - name: Checkout nillion repo
+            uses: actions/checkout@v3
+            with: 
+              path: nillion
+
+          - name: Install Go 1.22
+            uses: actions/setup-go@v3
+            with:
+              go-version: 1.22
+          # IBC requires building image locally for now. This can be changed in the future. 
+          - name: Build docker image
+            run: |
+             cd nillion
+             docker build -t local-image:v8.2.0 .
+
+          - name: Run E2E tests with custom chain image.
+            run: |
+              cd ibc-go
+              cd e2e
+              make e2e-test entrypoint=${{ matrix.entrypoint }} test=${{ matrix.test}}
+            env:
+              # Configure this however you like in order to specify your own custom image and tags.
+              CHAIN_IMAGE: local-image
+              # The following tags are used to specify the ibc-go version. This will be changed in the future.
+              CHAIN_A_TAG: v8.2.0
+              CHAIN_B_TAG: v8.2.0
+              CHAIN_BINARY: nilliond
+              RELAYER_ID: hermes
+              

--- a/.github/workflows/ibc-e2e.yml
+++ b/.github/workflows/ibc-e2e.yml
@@ -1,7 +1,7 @@
 ---
     name: Run ibc E2E Tests
     on:
-      workflow_dispatch:
+      push:
     jobs:
       e2e:
         runs-on: ubuntu-latest

--- a/.github/workflows/ibc-e2e.yml
+++ b/.github/workflows/ibc-e2e.yml
@@ -1,7 +1,7 @@
 ---
     name: Run ibc E2E Tests
     on:
-      push:
+      workflow_dispatch:
     jobs:
       e2e:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Adding IBC e2e tests that use the official ibc-go test suite but using the Nillion binary. This will be extremely useful when doing QA and ensuring we have all the functionality required. 

At present I am running two tests: First an IBC transfer which spins up two chains, the hermes binary and then executes an IBC transfer from one chain to another. The second test is being ran to ensure that governance is functioning correctly. 

Because these tests take quite a long time to run I have added them as workflow_dispatch only, meaning that we need to manually run the tests in the Actions UI. 

We can use this as a starting point for some happy/unhappy paths for our QA work. 