### PR TITLE
chore: Rename repo to nilliond

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Nillion Chain
+# nilliond
 
-Nillion Chain is the Coordination Layer for the Nillion Network. It coordinates the payment of blind
+nilliond is the Coordination Layer for the Nillion Network. It coordinates the payment of blind
 computations and storage operations performed on the network. It is built using the [Cosmos
 SDK](https://github.com/cosmos/cosmos-sdk), a framework for building PoS blockchain applications,
 which was chosen for the inter-connectivity, speed and sovereignty its ecosystem provides.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/NillionNetwork/nillion-chain
+module github.com/NillionNetwork/nilliond
 
 go 1.22.1
 

--- a/nilliond/cmd/root.go
+++ b/nilliond/cmd/root.go
@@ -40,8 +40,8 @@ import (
 
 	cmtcfg "github.com/cometbft/cometbft/config"
 
-	nillionapp "github.com/NillionNetwork/nillion-chain/app"
-	"github.com/NillionNetwork/nillion-chain/params"
+	nillionapp "github.com/NillionNetwork/nilliond/app"
+	"github.com/NillionNetwork/nilliond/params"
 )
 
 // NewRootCmd creates a new root command for nilliond. It is called once in the

--- a/nilliond/main.go
+++ b/nilliond/main.go
@@ -7,8 +7,8 @@ import (
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	nillionapp "github.com/NillionNetwork/nillion-chain/app"
-	"github.com/NillionNetwork/nillion-chain/nilliond/cmd"
+	nillionapp "github.com/NillionNetwork/nilliond/app"
+	"github.com/NillionNetwork/nilliond/nilliond/cmd"
 )
 
 func main() {


### PR DESCRIPTION
For branding purposes, we want to rename this repo to nilliond. This PR updates the go-imports, go.mod file and the README to reflect the change.