### PR TITLE
fix: e2e workflow

### DIFF
--- a/.github/workflows/ibc-e2e.yml
+++ b/.github/workflows/ibc-e2e.yml
@@ -54,4 +54,4 @@
               CHAIN_B_TAG: v8.2.0
               CHAIN_BINARY: nilliond
               RELAYER_ID: hermes
-              
+              BECH32_PREFIX: nillion 


### PR DESCRIPTION
adding env variable required by ibc-go now that we changed the bech32 prefix to nillion