### PR TITLE
fix: docker build in CI adds version to binary

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,10 +27,16 @@ jobs:
         flavor: |
           latest=false  # Ensure 'latest' tag is not generated
 
+    - name: Set version tag
+      id: set_tag
+      run: echo "VERSION_TAG=$(echo ${{ steps.meta.outputs.tags }} | cut -d ',' -f 1)" >> $GITHUB_ENV
+
     - name: Build Docker image
       uses: docker/build-push-action@v2
       with:
         context: .
+        build-args: |
+          VERSION=${{ env.VERSION_TAG }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Debug tags


### PR DESCRIPTION
At present when building from a tag in CI, the version is not correctly added to the binary. This is necessary for unblocking the e2e test work. 