### PR TITLE
fix: include .git folder in docker pre image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ADD nilchaind nilchaind
 ADD params params
 ADD x x 
 
+ADD .git .git
+
 COPY Makefile .
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
Before the images created did not have a version included in the binary, so nilchaind version was empty.