### PR TITLE
refactor: using maps.Clone to simplify the code

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -920,12 +921,7 @@ func (app *NillionApp) RegisterNodeService(clientCtx client.Context, cfg config.
 //
 // NOTE: This is solely to be used for testing purposes.
 func GetMaccPerms() map[string][]string {
-	dupMaccPerms := make(map[string][]string)
-	for k, v := range maccPerms {
-		dupMaccPerms[k] = v
-	}
-
-	return dupMaccPerms
+	return maps.Clone(maccPerms)
 }
 
 // BlockedAddresses returns all the app's blocked account addresses.


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/maps@go1.21.1#Clone) added in the go1.21 standard library, which can make the code more concise and easy to read.