### PR TITLE
fix: correct binary selection logic

### DIFF
--- a/tests/common/network.go
+++ b/tests/common/network.go
@@ -34,8 +34,9 @@ func (s *NetworkTestSuite) InitChain(version string, binary string) {
 
 	if version == "v0.1.1" {
 		binary = "nilliond"
+	} else {
+		binary = "nilchaind"
 	}
-	binary = "nilchaind"
 
 	client, network := interchaintest.DockerSetup(t)
 	s.DockerClient = client


### PR DESCRIPTION
Fixes broken binary selection logic where the legacy v0.1.1 case was always overridden